### PR TITLE
change button to invisible when all NFTs are loaded

### DIFF
--- a/src/components/explore/ExploreItems.jsx
+++ b/src/components/explore/ExploreItems.jsx
@@ -142,16 +142,18 @@ const ExploreItems = () => {
           </div>
         )
       )}
-      <div className="col-md-12 text-center">
-        <Link
-          to=""
-          id="loadmore"
-          className="btn-main lead"
-          onClick={handleLoadMore}
-        >
-          Load more
-        </Link>
-      </div>
+      {visibleCount < exploreItems.length && (
+        <div className="col-md-12 text-center">
+          <Link
+            to=""
+            id="loadmore"
+            className="btn-main lead"
+            onClick={handleLoadMore}
+          >
+            Load more
+          </Link>
+        </div>
+      )}
     </>
   );
 };


### PR DESCRIPTION
fixed functionality for "load more" button in the Explore page to disappear after all NFTs are loaded. 